### PR TITLE
Implements DnsOverHttps resolver in all network stacks

### DIFF
--- a/data/network/flashback/build.gradle.kts
+++ b/data/network/flashback/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
         androidMain.dependencies {
             implementation(libs.ktor.client.okHttp)
             implementation(libs.okhttp.loggingInterceptor)
+            implementation(libs.okhttp.dnsoverhttps)
         }
         commonMain.dependencies {
             implementation(projects.infrastructure)

--- a/data/network/flashback/src/androidMain/kotlin/tmg/flashback/flashbackapi/api/client/KtorClient.android.kt
+++ b/data/network/flashback/src/androidMain/kotlin/tmg/flashback/flashbackapi/api/client/KtorClient.android.kt
@@ -12,8 +12,13 @@ import io.ktor.http.ContentType
 import io.ktor.serialization.kotlinx.KotlinxSerializationConverter
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.serializer
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.dnsoverhttps.DnsOverHttps
 import okhttp3.logging.HttpLoggingInterceptor
 import tmg.flashback.infrastructure.device.Device
+import tmg.flashback.infrastructure.network.DnsUtils
+import java.net.InetAddress
 
 actual val KtorClient: HttpClient by lazy {
     Log.d("SDK","KtorClient Android")
@@ -23,6 +28,9 @@ actual val KtorClient: HttpClient by lazy {
         expectSuccess = true
 
         engine {
+            config {
+                dns(DnsUtils.dns)
+            }
             // add logging interceptor
             if (Device.isDebug) {
                 addInterceptor(

--- a/data/network/flashback/src/androidMain/kotlin/tmg/flashback/flashbackapi/api/client/KtorClient.android.kt
+++ b/data/network/flashback/src/androidMain/kotlin/tmg/flashback/flashbackapi/api/client/KtorClient.android.kt
@@ -1,37 +1,30 @@
 package tmg.flashback.flashbackapi.api.client
 
-import android.util.Log
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
-import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.plugins.logging.LogLevel
-import io.ktor.client.plugins.logging.Logging
 import io.ktor.http.ContentType
-import io.ktor.serialization.kotlinx.KotlinxSerializationConverter
 import io.ktor.serialization.kotlinx.json.json
-import kotlinx.serialization.serializer
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
-import okhttp3.dnsoverhttps.DnsOverHttps
 import okhttp3.logging.HttpLoggingInterceptor
 import tmg.flashback.infrastructure.device.Device
 import tmg.flashback.infrastructure.network.DnsUtils
-import java.net.InetAddress
 
 actual val KtorClient: HttpClient by lazy {
-    Log.d("SDK","KtorClient Android")
+
+    val okhttpClient = OkHttpClient.Builder().build()
+    val dns = DnsUtils.getDns(okhttpClient)
 
     HttpClient(OkHttp) {
         // default validation to throw exceptions for non-2xx responses
         expectSuccess = true
 
         engine {
-            config {
-                dns(DnsUtils.dns)
-            }
-            // add logging interceptor
+            preconfigured = okhttpClient
+                .newBuilder()
+                .dns(dns)
+                .build()
+
             if (Device.isDebug) {
                 addInterceptor(
                     HttpLoggingInterceptor().apply {

--- a/data/network/flashback_news/build.gradle.kts
+++ b/data/network/flashback_news/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
         androidMain.dependencies {
             implementation(libs.ktor.client.okHttp)
             implementation(libs.okhttp.loggingInterceptor)
+            implementation(libs.okhttp.dnsoverhttps)
         }
         commonMain.dependencies {
             implementation(projects.infrastructure)

--- a/data/network/flashback_news/src/androidMain/kotlin/tmg/flashback/news/client/KtorClient.android.kt
+++ b/data/network/flashback_news/src/androidMain/kotlin/tmg/flashback/news/client/KtorClient.android.kt
@@ -14,6 +14,7 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.serializer
 import okhttp3.logging.HttpLoggingInterceptor
 import tmg.flashback.infrastructure.device.Device
+import tmg.flashback.infrastructure.network.DnsUtils
 
 actual val KtorClient: HttpClient by lazy {
     Log.d("SDK","KtorClient Android")
@@ -23,6 +24,9 @@ actual val KtorClient: HttpClient by lazy {
         expectSuccess = true
 
         engine {
+            config {
+                dns(DnsUtils.dns)
+            }
             // add logging interceptor
             if (Device.isDebug) {
                 addInterceptor(

--- a/data/network/flashback_news/src/androidMain/kotlin/tmg/flashback/news/client/KtorClient.android.kt
+++ b/data/network/flashback_news/src/androidMain/kotlin/tmg/flashback/news/client/KtorClient.android.kt
@@ -1,32 +1,29 @@
 package tmg.flashback.news.client
 
-import android.util.Log
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
-import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.plugins.logging.LogLevel
-import io.ktor.client.plugins.logging.Logging
 import io.ktor.http.ContentType
-import io.ktor.serialization.kotlinx.KotlinxSerializationConverter
 import io.ktor.serialization.kotlinx.json.json
-import kotlinx.serialization.serializer
+import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import tmg.flashback.infrastructure.device.Device
 import tmg.flashback.infrastructure.network.DnsUtils
 
 actual val KtorClient: HttpClient by lazy {
-    Log.d("SDK","KtorClient Android")
+
+    val okhttpClient = OkHttpClient.Builder().build()
+    val dns = DnsUtils.getDns(okhttpClient)
 
     HttpClient(OkHttp) {
         // default validation to throw exceptions for non-2xx responses
         expectSuccess = true
-
         engine {
-            config {
-                dns(DnsUtils.dns)
-            }
+            preconfigured = okhttpClient
+                .newBuilder()
+                .dns(dns)
+                .build()
+
             // add logging interceptor
             if (Device.isDebug) {
                 addInterceptor(

--- a/data/network/rss/build.gradle.kts
+++ b/data/network/rss/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
         androidMain.dependencies {
             implementation(libs.ktor.client.okHttp)
             implementation(libs.okhttp.loggingInterceptor)
+            implementation(libs.okhttp.dnsoverhttps)
         }
         commonMain.dependencies {
             implementation(projects.infrastructure)

--- a/data/network/rss/src/androidMain/kotlin/tmg/flashback/network/rss/client/KtorClient.android.kt
+++ b/data/network/rss/src/androidMain/kotlin/tmg/flashback/network/rss/client/KtorClient.android.kt
@@ -4,20 +4,26 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.xml.xml
+import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import tmg.flashback.infrastructure.device.Device
 import tmg.flashback.infrastructure.network.DnsUtils
 
 actual val KtorClient: HttpClient by lazy {
+
+    val okhttpClient = OkHttpClient.Builder().build()
+    val dns = DnsUtils.getDns(okhttpClient)
+
     HttpClient(OkHttp) {
         // default validation to throw exceptions for non-2xx responses
         expectSuccess = true
 
         engine {
-            config {
-                dns(DnsUtils.dns)
-            }
-            // add logging interceptor
+            preconfigured = okhttpClient
+                .newBuilder()
+                .dns(dns)
+                .build()
+
             if (Device.isDebug) {
                 addInterceptor(
                     HttpLoggingInterceptor().apply {

--- a/data/network/rss/src/androidMain/kotlin/tmg/flashback/network/rss/client/KtorClient.android.kt
+++ b/data/network/rss/src/androidMain/kotlin/tmg/flashback/network/rss/client/KtorClient.android.kt
@@ -1,21 +1,22 @@
 package tmg.flashback.network.rss.client
 
-import android.util.Log
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.xml.xml
 import okhttp3.logging.HttpLoggingInterceptor
 import tmg.flashback.infrastructure.device.Device
+import tmg.flashback.infrastructure.network.DnsUtils
 
 actual val KtorClient: HttpClient by lazy {
-    Log.d("SDK","KtorClient Android")
-
     HttpClient(OkHttp) {
         // default validation to throw exceptions for non-2xx responses
         expectSuccess = true
 
         engine {
+            config {
+                dns(DnsUtils.dns)
+            }
             // add logging interceptor
             if (Device.isDebug) {
                 addInterceptor(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ firebase-bom = "34.1.0"
 
 # Shared
 ktor = "3.2.3"
-okHttpLoggingInterceptor = "5.1.0"
+okhttp = "5.1.0"
 compose = "1.8.2"
 composeUiTooling = "1.9.0"
 composeAdaptive = "1.1.2"
@@ -110,7 +110,8 @@ ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-apache = { module = "io.ktor:ktor-client-apache", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-serialization-kotlinx-xml = { module = "io.ktor:ktor-serialization-kotlinx-xml", version.ref = "ktor" }
-okhttp-loggingInterceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okHttpLoggingInterceptor" }
+okhttp-loggingInterceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
+okhttp-dnsoverhttps = { module = "com.squareup.okhttp3:okhttp-dnsoverhttps", version.ref = "okhttp"}
 
 # Test
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }

--- a/infrastructure/build.gradle.kts
+++ b/infrastructure/build.gradle.kts
@@ -14,11 +14,20 @@ kotlin {
                 jvmTarget.set(JvmTarget.JVM_17)
             }
         }
+        androidMain.dependencies {
+            implementation(libs.ktor.client.okHttp)
+            implementation(libs.okhttp.loggingInterceptor)
+            implementation(libs.okhttp.dnsoverhttps)
+        }
         commonMain.dependencies {
+            implementation(libs.bundles.common.ktor)
             implementation(libs.bundles.kotlin)
         }
         commonTest.dependencies {
             implementation(kotlin("test"))
+        }
+        iosMain.dependencies {
+            implementation(libs.ktor.client.darwin)
         }
     }
 }

--- a/infrastructure/src/androidMain/kotlin/tmg/flashback/infrastructure/network/DnsUtils.kt
+++ b/infrastructure/src/androidMain/kotlin/tmg/flashback/infrastructure/network/DnsUtils.kt
@@ -1,0 +1,16 @@
+package tmg.flashback.infrastructure.network
+
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.dnsoverhttps.DnsOverHttps
+import java.net.InetAddress
+
+object DnsUtils {
+    val dns = DnsOverHttps.Builder()
+        .url("https://1.1.1.1/dns-query".toHttpUrl())
+        .includeIPv6(false)
+        .bootstrapDnsHosts(
+            InetAddress.getByName("1.1.1.1"),
+            InetAddress.getByName("8.8.8.8")
+        )
+        .build()
+}

--- a/infrastructure/src/androidMain/kotlin/tmg/flashback/infrastructure/network/DnsUtils.kt
+++ b/infrastructure/src/androidMain/kotlin/tmg/flashback/infrastructure/network/DnsUtils.kt
@@ -1,11 +1,13 @@
 package tmg.flashback.infrastructure.network
 
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
 import okhttp3.dnsoverhttps.DnsOverHttps
 import java.net.InetAddress
 
 object DnsUtils {
-    val dns = DnsOverHttps.Builder()
+    fun getDns(client: OkHttpClient) = DnsOverHttps.Builder()
+        .client(client)
         .url("https://1.1.1.1/dns-query".toHttpUrl())
         .includeIPv6(false)
         .bootstrapDnsHosts(


### PR DESCRIPTION
Attempts to solve this crash by providing custom DnsOverHttps resolver

```
Fatal Exception: java.net.UnknownHostException: Unable to resolve host "flashback.pages.dev": No address associated with hostname
       at java.net.Inet6AddressImpl.lookupHostByName(Inet6AddressImpl.java:156)
       at java.net.Inet6AddressImpl.lookupAllHostAddr(Inet6AddressImpl.java:103)
       at java.net.InetAddress.getAllByName(InetAddress.java:1152)
       at okhttp3.Dns$Companion$DnsSystem.lookup(Dns.java:50)
       at okhttp3.internal.connection.RouteSelector.resetNextInetSocketAddress(RouteSelector.java:171)
       at okhttp3.internal.connection.RouteSelector.nextProxy(RouteSelector.java:133)
       at okhttp3.internal.connection.RouteSelector.next(RouteSelector.java:71)
       at okhttp3.internal.connection.RealRoutePlanner.planConnect$okhttp(RealRoutePlanner.kt:162)
       at okhttp3.internal.connection.RealRoutePlanner.plan(RealRoutePlanner.kt:73)
       at okhttp3.internal.connection.FastFallbackExchangeFinder.launchTcpConnect(FastFallbackExchangeFinder.kt:119)
       at okhttp3.internal.connection.FastFallbackExchangeFinder.find(FastFallbackExchangeFinder.kt:62)
       at okhttp3.internal.connection.RealCall.initExchange$okhttp(RealCall.java:280)
       at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:32)
       at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:126)
       at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:101)
       at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:126)
       at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:85)
       at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:126)
       at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:74)
       at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:126)
       at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:208)
       at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:530)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1156)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:651)
       at java.lang.Thread.run(Thread.java:1119)
```