### PR TITLE
Revert "Update androidx.lifecycle to v2.9.3"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ android-compileSdk = "36"
 android-minSdk = "26"
 android-targetSdk = "36"
 androidx-activityCompose = "1.10.1"
-androidx-lifecycle = "2.9.3"
+androidx-lifecycle = "2.9.2"
 androidx-glance = "1.1.1"
 
 # Firebase


### PR DESCRIPTION
Reverts thementalgoose/kmp-flashback#110

Reverting as it brings in https://github.com/thementalgoose/kmp-flashback/pull/49, but this is preventing the iOS build from succeeding