### PR TITLE
Try catch session creation for XR

### DIFF
--- a/composeApp/src/androidMain/kotlin/tmg/flashback/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/tmg/flashback/MainActivity.kt
@@ -38,8 +38,12 @@ class MainActivity : BaseActivity(), SplashScreen.KeepOnScreenCondition {
         setTheme(theme)
         splashScreen.setKeepOnScreenCondition(this)
 
-        val session = Session.create(this)
-        Log.i("INFO", "Session creation $session")
+        try {
+            val session = Session.create(this)
+            Log.i("INFO", "Session creation $session")
+        } catch (e: Throwable) {
+            /* Safely ignore */
+        }
 
         setContent {
             App()


### PR DESCRIPTION
```
Caused by java.lang.IllegalStateException
Neither ARCore nor SceneCore are available. Did you forget to add a dependency?
  androidx.xr.runtime.Session$Companion.create (Session.kt:232)
  androidx.xr.runtime.Session$Companion.create (Session.kt:143)
  androidx.xr.runtime.Session$Companion.create (Session.kt:114)
  androidx.xr.runtime.Session$Companion.create (Session.kt:114)
  androidx.xr.runtime.Session$Companion.create$default (Session.kt:107)
  tmg.flashback.MainActivity.onCreate (MainActivity.kt:41)
```