### PR TITLE
Updates renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,11 +9,10 @@
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
-      "groupName": "kotlin",
       "matchPackageNames": [
-        "/^org.jetbrains.kotlin.$/",
-        "/^com.google.devtools.ksp/"
-      ]
+        "/^androidx\\.xr\\./"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
- Remove kotlin renovation block which groups kotlin + KSP now that KSP is decoupled from Kotlin
- Add exclude for `androidx.xr` to stop PRs from constantly being raised